### PR TITLE
Add pub-sub infrastructure and APIs

### DIFF
--- a/Dapr.PluggableComponents.Complete.sln
+++ b/Dapr.PluggableComponents.Complete.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{FFFE01DC-8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapr.PluggableComponents.Protos", "src\Dapr.PluggableComponents.Protos\Dapr.PluggableComponents.Protos.csproj", "{D4EEE026-43B8-42F7-B704-388CA4A0E6EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureStorageQueuesPubSubSample", "samples\AzureStorageQueuesPubSubSample\AzureStorageQueuesPubSubSample.csproj", "{A6565BA8-E05C-4B4E-A908-C4B86232F9AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,11 +44,16 @@ Global
 		{D4EEE026-43B8-42F7-B704-388CA4A0E6EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4EEE026-43B8-42F7-B704-388CA4A0E6EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4EEE026-43B8-42F7-B704-388CA4A0E6EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6565BA8-E05C-4B4E-A908-C4B86232F9AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6565BA8-E05C-4B4E-A908-C4B86232F9AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6565BA8-E05C-4B4E-A908-C4B86232F9AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6565BA8-E05C-4B4E-A908-C4B86232F9AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E54270BE-EF83-47BE-B29C-29BC89701099} = {8E8203A7-A0B9-4F48-9CD4-DE9A0D3B73FB}
 		{26D29BDF-8453-411F-B91F-C13BF24E5203} = {8E8203A7-A0B9-4F48-9CD4-DE9A0D3B73FB}
 		{B9AC2D9C-6E9D-42BC-92D2-7427646F28D9} = {6F4E950F-E4CD-4FA4-BA3D-528F0022C03B}
 		{D4EEE026-43B8-42F7-B704-388CA4A0E6EE} = {8E8203A7-A0B9-4F48-9CD4-DE9A0D3B73FB}
+		{A6565BA8-E05C-4B4E-A908-C4B86232F9AB} = {6F4E950F-E4CD-4FA4-BA3D-528F0022C03B}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ app.Run();
 Implement one or more component interfaces.
 
 - `Dapr.PluggableComponents.StateStore.IStateStore`: The interface for state store components.
+- `Dapr.PluggableComponents.PubSub.IPubSub`: The interface for pub-sub components.
 
 Register one or more component types with the service.
 
@@ -53,11 +54,19 @@ app.RegisterService(
     {
         // Register a state store with the service.
         serviceBuilder.RegisterStateStore<MyStateStore>();
+
+        // Register a pub-sub component with the service.
+        serviceBuilder.RegisterPubSub<MyPubSub>();
     });
 
 app.Run();
 
 class MyStateStore : IStateStore
+{
+    // ...
+}
+
+class MyPubSub : IPubSub
 {
     // ...
 }

--- a/samples/AzureStorageQueuesPubSubSample/AzureStorageQueuesPubSub.cs
+++ b/samples/AzureStorageQueuesPubSubSample/AzureStorageQueuesPubSub.cs
@@ -1,0 +1,135 @@
+using Azure.Storage.Queues;
+using Dapr.PluggableComponents.Components;
+using Dapr.PluggableComponents.Components.PubSub;
+
+internal sealed class AzureStorageQueuesPubSub : IPubSub
+{
+    private readonly ILogger<AzureStorageQueuesPubSub> logger;
+
+    private string? connectionString;
+    private string? queueName;
+    private TimeSpan pollInterval = TimeSpan.FromSeconds(5);
+    private int maxMessages = 5; 
+
+    public AzureStorageQueuesPubSub(ILogger<AzureStorageQueuesPubSub> logger)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    #region IPubSub Members
+
+    public Task InitAsync(MetadataRequest request, CancellationToken cancellationToken = default)
+    {
+        this.logger.LogInformation("Init request");
+
+        this.connectionString = request.Properties["connectionString"];
+        this.queueName = request.Properties["queueName"];
+
+        if (request.Properties.TryGetValue("pollIntervalSeconds", out var pollIntervalString))
+        {
+            this.pollInterval = TimeSpan.FromSeconds(Int32.Parse(pollIntervalString));
+        }
+
+        if (request.Properties.TryGetValue("maxMessages", out var maxMessagesString))
+        {
+            this.maxMessages = Int32.Parse(maxMessagesString);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task PublishAsync(PubSubPublishRequest request, CancellationToken cancellationToken = default)
+    {
+        this.logger.LogInformation("Publish request");
+
+        var queueClient = new QueueClient(this.connectionString, this.queueName);
+
+        await queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+        await queueClient.SendMessageAsync(Encoding.UTF8.GetString(request.Data.Span), cancellationToken);
+    }
+
+    public async Task PullMessagesAsync(PubSubPullMessagesTopic topic, MessageDeliveryHandler handler, CancellationToken cancellationToken = default)
+    {
+        this.logger.LogInformation("Pull messages request for topic \"{0}\"", topic.Name);
+
+        var queueClient = new QueueClient(this.connectionString, this.queueName);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var response = await queueClient.ReceiveMessagesAsync(this.maxMessages, cancellationToken: cancellationToken);
+
+            this.logger.LogInformation("Received messages: {0}", response.Value.Length);
+
+            foreach (var message in response.Value)
+            {
+                var cloudEventBytes = message.Body.ToArray();
+                var cloudEvent = JsonSerializer.Deserialize<CloudEvent>(Encoding.UTF8.GetString(cloudEventBytes));
+
+                if (cloudEvent != null && cloudEvent.Topic != null)
+                {
+                    this.logger.LogInformation("Delivering message {0}.", cloudEvent.Id);
+
+                    await handler(
+                        new PubSubPullMessagesResponse(cloudEvent.Topic)
+                        {
+                            ContentType = cloudEvent.DataContentType,
+                            Data = cloudEventBytes
+                        },
+                        async errorMessage =>
+                        {
+                            this.logger.LogInformation("Acknowledgement for message {0} received with error: {1}", cloudEvent.Id, errorMessage);
+
+                            if (String.IsNullOrEmpty(errorMessage))
+                            {
+                                await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+                            }
+                        });
+                }
+            }
+
+            await Task.Delay(this.pollInterval, cancellationToken);
+        }
+    }
+
+    #endregion
+
+    private sealed class CloudEvent
+    {
+        [JsonPropertyName("data")]
+        public string? Data { get; init; }
+
+        [JsonPropertyName("datacontenttype")]
+        public string? DataContentType { get; init; }
+
+        [JsonPropertyName("id")]
+        public string? Id { get; init;}
+
+        [JsonPropertyName("pubsubname")]
+        public string? PubSubName { get; init; }
+
+        [JsonPropertyName("source")]
+        public string? Source { get; init; }
+
+        [JsonPropertyName("specversion")]
+        public string? SpecVersion { get; init; }
+
+        [JsonPropertyName("time")]
+        public string? Time { get; init; }
+
+        [JsonPropertyName("topic")]
+        public string? Topic { get; init; }
+
+        [JsonPropertyName("traceid")]
+        public string? TraceId { get; init; }
+
+        [JsonPropertyName("traceparent")]
+        public string? TraceParent { get; init; }
+
+        [JsonPropertyName("tracestate")]
+        public string? TraceState { get; init; }
+
+        [JsonPropertyName("type")]
+        public string? Type { get; init; }
+    }
+}

--- a/samples/AzureStorageQueuesPubSubSample/AzureStorageQueuesPubSubSample.csproj
+++ b/samples/AzureStorageQueuesPubSubSample/AzureStorageQueuesPubSubSample.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Text" />
+    <Using Include="System.Text.Json" />
+    <Using Include="System.Text.Json.Serialization" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dapr.PluggableComponents.AspNetCore\Dapr.PluggableComponents.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+  </ItemGroup>
+</Project>

--- a/samples/AzureStorageQueuesPubSubSample/Program.cs
+++ b/samples/AzureStorageQueuesPubSubSample/Program.cs
@@ -1,0 +1,22 @@
+﻿using Dapr.PluggableComponents;
+
+var app = DaprPluggableComponentsApplication.Create();
+
+app.RegisterService(
+    "azure-storage-queues",
+    serviceBuilder =>
+    {
+        // Use this registration method to have a single pub-sub instance for all components.
+        // serviceBuilder.RegisterPubSub<AzureStorageQueuesPubSub>();
+
+        // This registration method enables a pub-sub instance per component instance.
+        serviceBuilder.RegisterPubSub(
+            context =>
+            {
+                Console.WriteLine("Creating pub-sub for instance '{0}' on socket '{1}'...", context.InstanceId, context.SocketPath);
+
+                return new AzureStorageQueuesPubSub(context.ServiceProvider.GetRequiredService<ILogger<AzureStorageQueuesPubSub>>());
+            });
+    });
+
+app.Run();

--- a/samples/AzureStorageQueuesPubSubSample/README.md
+++ b/samples/AzureStorageQueuesPubSubSample/README.md
@@ -1,0 +1,39 @@
+# Azure Storage Queues Pub-Sub Sample
+
+A Dapr Pluggable Component sample that allows applications to use Azure Storage Queues as a pub-sub component.
+
+## Prerequisites
+
+1. Create an Azure Storage resource for an Azure subscription in the Azure Portal.
+1. Create a queue within the storage resource.
+
+## Configuration
+
+An application that binds to the component should have a Pluggable Component configuration file that looks like the following:
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: azure-storage-queues
+spec:
+  type: pubsub.azure-storage-queues
+  version: v1
+  metadata:
+  - name: connectionString
+    value: "<connection string>"
+  - name: queueName
+    value: "<queue name>"
+  - name: pollIntervalSeconds
+    value: <poll interval in seconds>
+  - name: maxMessages
+    value: <max messages to receive per poll>
+```
+
+The required metadata properties are `<connection string>`, the connection string for the Azure Storage resource, and `<queue name>`, the name of the queue to be polled for messages. The `pollIntervalSeconds` and `maxMessages` properties are optional.
+
+> NOTE: To prevent tokens from being mistakenly committed to a repro, it is best to use Dapr secrets components to store the connection string and then simply reference it from the binding component configuration.
+
+## Application
+
+The application can publish messages to the queue, or subscribe to messages published to the queue, using [HTTP](https://docs.dapr.io/reference/api/pubsub_api/) or the [Dapr Client SDKs](https://docs.dapr.io/developing-applications/sdks/).

--- a/samples/AzureStorageQueuesPubSubSample/appsettings.Development.json
+++ b/samples/AzureStorageQueuesPubSubSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/AzureStorageQueuesPubSubSample/appsettings.json
+++ b/samples/AzureStorageQueuesPubSubSample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Dapr.PluggableComponents.AspNetCore/DaprPluggableComponentsServiceBuilder.cs
+++ b/src/Dapr.PluggableComponents.AspNetCore/DaprPluggableComponentsServiceBuilder.cs
@@ -12,6 +12,7 @@
 // ------------------------------------------------------------------------
 
 using Dapr.PluggableComponents.Adaptors;
+using Dapr.PluggableComponents.Components.PubSub;
 using Dapr.PluggableComponents.Components.StateStore;
 
 namespace Dapr.PluggableComponents;
@@ -47,6 +48,49 @@ public sealed class DaprPluggableComponentsServiceBuilder
         this.socketPath = socketPath;
         this.registrar = registrar;
     }
+
+    #region Pub-Sub Registration
+
+    /// <summary>
+    /// Registers a singleton pub-sub component with this service.
+    /// </summary>
+    /// <typeparam name="TPubSub">The type of pub-sub component to register.</typeparam>
+    /// <returns>The current <see cref="DaprPluggableComponentsServiceBuilder"/> instance.</returns>
+    /// <remarks>
+    /// A single instance of the pub-sub component will be created to service all configured Dapr components.
+    ///
+    /// Only a single pub-sub component type can be associated with a given service.
+    /// </remarks>
+    public DaprPluggableComponentsServiceBuilder RegisterPubSub<TPubSub>() where TPubSub : class, IPubSub
+    {
+        this.AddComponent<IPubSub, TPubSub, PubSubAdaptor>();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a pub-sub component with this service.
+    /// </summary>
+    /// <typeparam name="TPubSub">The type of pub-sub component to register.</typeparam>
+    /// <param name="pubSubFactory">A factory method called when creating new pub-sub component instances.</param>
+    /// <returns>The current <see cref="DaprPluggableComponentsServiceBuilder"/> instance.</returns>
+    /// <remarks>
+    /// The factory method will be called once for each configured Dapr component; the returned instance will be
+    /// associated with that Dapr component and methods invoked when the component receives requests.
+    ///
+    /// Only a single pub-sub component type can be associated with a given service.
+    /// </remarks>
+    public DaprPluggableComponentsServiceBuilder RegisterPubSub<TPubSub>(ComponentProviderDelegate<TPubSub> pubSubFactory)
+        where TPubSub : class, IPubSub
+    {
+        this.AddComponent<IPubSub, TPubSub, PubSubAdaptor>(pubSubFactory);
+
+        return this;
+    }
+
+    #endregion
+
+    #region State Store Registration
 
     /// <summary>
     /// Registers a singleton state store with this service.
@@ -84,6 +128,8 @@ public sealed class DaprPluggableComponentsServiceBuilder
 
         return this;
     }
+
+    #endregion
 
     private void AddComponent<TComponentType, TComponentImpl, TAdaptor>()
         where TComponentType : class

--- a/src/Dapr.PluggableComponents/Adaptors/PubSubAdaptor.cs
+++ b/src/Dapr.PluggableComponents/Adaptors/PubSubAdaptor.cs
@@ -1,0 +1,176 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Dapr.Client.Autogen.Grpc.v1;
+using Dapr.PluggableComponents.Components;
+using Dapr.PluggableComponents.Components.PubSub;
+using Dapr.PluggableComponents.Utilities;
+using Dapr.Proto.Components.V1;
+using Google.Protobuf;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using static Dapr.Proto.Components.V1.PubSub;
+
+namespace Dapr.PluggableComponents.Adaptors;
+
+/// <summary>
+/// Represents the gRPC protocol adaptor for a pub-sub Dapr Pluggable Component.
+/// </summary>
+/// <remarks>
+/// An instances of this class is created for every request made to the component.
+/// </remarks>
+public class PubSubAdaptor : PubSubBase
+{
+    private readonly ILogger<PubSubAdaptor> logger;
+    private readonly IDaprPluggableComponentProvider<IPubSub> componentProvider;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="PubSubAdaptor"/> class.
+    /// </summary>
+    /// <param name="logger">A logger used for internal purposes.</param>
+    /// <param name="componentProvider">A means to obtain the Dapr Pluggable Component associated with this adapter instance.</param>
+    /// <exception cref="ArgumentNullException">If any parameter is null.</exception>
+    public PubSubAdaptor(ILogger<PubSubAdaptor> logger, IDaprPluggableComponentProvider<IPubSub> componentProvider)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.componentProvider = componentProvider ?? throw new ArgumentNullException(nameof(componentProvider));
+    }
+
+    /// <inheritdoc/>
+    public override async Task<FeaturesResponse> Features(FeaturesRequest request, ServerCallContext ctx)
+    {
+        this.logger.LogDebug("Features request");
+
+        var response = new FeaturesResponse();
+
+        if (this.GetPubSub(ctx) is IPluggableComponentFeatures features)
+        {
+            var featuresResponse = await features.GetFeaturesAsync(ctx.CancellationToken);
+    
+            response.Features.AddRange(featuresResponse);
+        }
+
+        return response;
+    }
+
+    /// <inheritdoc/>
+    public async override Task<PubSubInitResponse> Init(Proto.Components.V1.PubSubInitRequest request, ServerCallContext ctx)
+    {
+        this.logger.LogDebug("Init request");
+        
+        await this.GetPubSub(ctx).InitAsync(
+            Components.MetadataRequest.FromMetadataRequest(request.Metadata),
+            ctx.CancellationToken);
+        
+        return new PubSubInitResponse();
+    }
+
+    /// <inheritdoc/>
+    public override async Task<PingResponse> Ping(PingRequest request, ServerCallContext ctx)
+    {
+        this.logger.LogDebug("Ping request");
+
+        if (this.GetPubSub(ctx) is IPluggableComponentLiveness ping)
+        {
+            await ping.PingAsync(ctx.CancellationToken);
+        }
+
+        return new PingResponse();
+    }
+
+    /// <inheritdoc/>
+    public override async Task<PublishResponse> Publish(PublishRequest request, ServerCallContext context)
+    {
+        this.logger.LogDebug("Publish request");
+
+        await this.GetPubSub(context).PublishAsync(
+            new PubSubPublishRequest(request.PubsubName, request.Topic)
+            {
+                ContentType = request.ContentType,
+                Data = request.Data.Memory,
+                Metadata = request.Metadata
+            },
+            context.CancellationToken);
+
+        return new PublishResponse();
+    }
+
+    /// <inheritdoc/>
+    public override async Task PullMessages(IAsyncStreamReader<PullMessagesRequest> requests, IServerStreamWriter<PullMessagesResponse> responses, ServerCallContext context)
+    {
+        this.logger.LogDebug("Pull messages request");
+
+        // The first request should contain the topic from which to pull messages.
+        if (!await requests.MoveNext(context.CancellationToken))
+        {
+            throw new InvalidOperationException("The component expects at least one request.");
+        }
+
+        var topic = requests.Current.Topic;
+
+        if (topic == null || String.IsNullOrEmpty(topic.Name))
+        {
+            throw new InvalidOperationException("The component expects the first request to specify the topic.");
+        }
+
+        var pendingMessages = new ConcurrentDictionary<string, MessageAcknowledgementHandler>();
+
+        var acknowledgeTask =
+            async () =>
+            {
+                while (await requests.MoveNext(context.CancellationToken))
+                {
+                    var request = requests.Current;
+
+                    if (request.AckMessageId != null && pendingMessages.TryRemove(request.AckMessageId, out var response))
+                    {
+                        await response(request.AckError?.Message);
+                    }
+                }
+            };
+
+        var pullTask = this.GetPubSub(context).PullMessagesAsync(
+            new PubSubPullMessagesTopic(topic.Name) { Metadata = requests.Current.Topic.Metadata },
+            async (message, onAcknowledgement) =>
+            {
+                string messageId = Guid.NewGuid().ToString();
+
+                var response = PubSubPullMessagesResponse.ToPullMessagesResponse(messageId, message);
+
+                response.Metadata.Add(message.Metadata);
+
+                pendingMessages[messageId] = onAcknowledgement;
+
+                try
+                {
+                    await responses.WriteAsync(response);
+                }
+                catch
+                {
+                    // If unable to write the message, there shouldn't be an acknowledgement.
+                    pendingMessages.TryRemove(messageId, out var _);
+
+                    throw;
+                }
+            },
+            context.CancellationToken);
+
+        await Task.WhenAll(acknowledgeTask(), pullTask);
+    }
+
+    private IPubSub GetPubSub(ServerCallContext context)
+    {
+        return this.componentProvider.GetComponent(context);
+    }
+}

--- a/src/Dapr.PluggableComponents/Adaptors/StateStoreAdaptor.cs
+++ b/src/Dapr.PluggableComponents/Adaptors/StateStoreAdaptor.cs
@@ -39,7 +39,7 @@ public class StateStoreAdaptor : StateStoreBase
     /// </summary>
     /// <param name="logger">A logger used for internal purposes.</param>
     /// <param name="componentProvider">A means to obtain the Dapr Pluggable Component associated with this adapter instance.</param>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentNullException">If any parameter is null.</exception>
     public StateStoreAdaptor(ILogger<StateStoreAdaptor> logger, IDaprPluggableComponentProvider<IStateStore> componentProvider)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/Dapr.PluggableComponents/Components/PubSub/IPubSub.cs
+++ b/src/Dapr.PluggableComponents/Components/PubSub/IPubSub.cs
@@ -1,0 +1,52 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.PluggableComponents.Components.PubSub;
+
+/// <summary>
+/// Represents the handler used to receive acknowledgement of a processed message.
+/// </summary>
+/// <param name="errorMessage">The error message associated with processing the message, if any.</param>
+/// <returns></returns>
+public delegate Task MessageAcknowledgementHandler(string? errorMessage);
+
+/// <summary>
+/// Represents the handler used to deliver messages to the (Dapr) client.
+/// </summary>
+/// <param name="response">The response (i.e. message) to deliver to the (Dapr) client.</param>
+/// <param name="onAcknowledgement">A handler to receive acknowledgement of the processed message.</param>
+/// <returns></returns>
+public delegate Task MessageDeliveryHandler(PubSubPullMessagesResponse response, MessageAcknowledgementHandler onAcknowledgement);
+
+/// <summary>
+/// Represents a pub-sub Dapr Pluggable Component.
+/// </summary>
+public interface IPubSub : IPluggableComponent
+{
+    /// <summary>
+    /// Called to publish a message.
+    /// </summary>
+    /// <param name="request">Properties related to the message being published.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PublishAsync(PubSubPublishRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Called to establish a stream through which messages can be returned to the (Dapr) client and Dapr acknowledgements returned to the component.
+    /// </summary>
+    /// <param name="topic">The topic for which to pull messages.</param>
+    /// <param name="deliveryHandler">The handler used to deliver messages to the (Dapr) client.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PullMessagesAsync(PubSubPullMessagesTopic topic, MessageDeliveryHandler deliveryHandler, CancellationToken cancellationToken = default);
+}

--- a/src/Dapr.PluggableComponents/Components/PubSub/PubSubPublishRequest.cs
+++ b/src/Dapr.PluggableComponents/Components/PubSub/PubSubPublishRequest.cs
@@ -1,0 +1,37 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.PluggableComponents.Components.PubSub;
+
+/// <summary>
+/// Represents properties associated with a message to be published.
+/// </summary>
+/// <param name="PubSubName">Gets the name of the pub-sub component.</param>
+/// <param name="Topic">Gets the topic on which to publish the message.</param>
+public sealed record PubSubPublishRequest(string PubSubName, string Topic)
+{
+    /// <summary>
+    /// Gets the message data.
+    /// </summary>
+    public ReadOnlyMemory<byte> Data { get; init; } = ReadOnlyMemory<byte>.Empty;
+
+    /// <summary>
+    /// Gets the metadata associated with the request.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets the content type of the message.
+    /// </summary>
+    public string? ContentType { get; init; }
+}

--- a/src/Dapr.PluggableComponents/Components/PubSub/PubSubPullMessagesResponse.cs
+++ b/src/Dapr.PluggableComponents/Components/PubSub/PubSubPullMessagesResponse.cs
@@ -1,0 +1,59 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Dapr.PluggableComponents.Utilities;
+using Dapr.Proto.Components.V1;
+using Google.Protobuf;
+
+namespace Dapr.PluggableComponents.Components.PubSub;
+
+/// <summary>
+/// Represents a message being "pulled" from the source and delivered to the (Dapr) client.
+/// </summary>
+/// <param name="TopicName">Gets the name of the topic on which the message was published.</param>
+/// <remarks>
+/// This type is considered a "response" because it is sent by the component in response to the (Dapr) client calling
+/// <see cref="IPubSub.PullMessagesAsync(Dapr.PluggableComponents.Components.PubSub.PubSubPullMessagesTopic, Dapr.PluggableComponents.Components.PubSub.MessageDeliveryHandler, CancellationToken)" />.
+/// </remarks>
+public sealed record PubSubPullMessagesResponse(string TopicName)
+{
+    /// <summary>
+    /// Gets the message data.
+    /// </summary>
+    public byte[] Data { get; init; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets the metadata associated with the request.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets the content type of the message.
+    /// </summary>
+    public string? ContentType { get; init; }
+
+    internal static PullMessagesResponse ToPullMessagesResponse(string messageId, PubSubPullMessagesResponse message)
+    {
+        var grpcResponse = new PullMessagesResponse
+        {
+            ContentType = message.ContentType ?? String.Empty,
+            Data = message.Data != null ? ByteString.CopyFrom(message.Data) : ByteString.Empty,
+            Id = messageId,
+            TopicName = message.TopicName
+        };
+
+        grpcResponse.Metadata.Add(message.Metadata);
+
+        return grpcResponse;
+    }
+}

--- a/src/Dapr.PluggableComponents/Components/PubSub/PubSubPullMessagesTopic.cs
+++ b/src/Dapr.PluggableComponents/Components/PubSub/PubSubPullMessagesTopic.cs
@@ -1,0 +1,26 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.PluggableComponents.Components.PubSub;
+
+/// <summary>
+/// Represents the topic associated with a message stream.
+/// </summary>
+/// <param name="Name">Gets the name of the topic.</param>
+public sealed record PubSubPullMessagesTopic(string Name)
+{
+    /// <summary>
+    /// Gets the metadata associated with the topic.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+}


### PR DESCRIPTION
Adds the gRPC adaptor, interface and request types, and service registration methods for creating pub-sub components. Also adds a sample pub-sub component for Azure Storage Queues.