### PR TITLE
Allow return of ETag-specific errors from state stores.

### DIFF
--- a/src/Dapr.PluggableComponents/Components/StateStore/BulkDeleteRowMismatchException.cs
+++ b/src/Dapr.PluggableComponents/Components/StateStore/BulkDeleteRowMismatchException.cs
@@ -1,0 +1,50 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Globalization;
+using Grpc.Core;
+
+namespace Dapr.PluggableComponents.Components.StateStore;
+
+/// <summary>
+/// An exception that represents an occurrence of a bulk deletion not effecting the expected number of rows.
+/// </summary>
+/// <remarks>
+/// This exception should be thrown only from bulk delete operations.
+/// </remarks>
+public sealed class BulkDeleteRowMismatchException : RpcException
+{
+    private const StatusCode BaseStatusCode = StatusCode.Internal;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BulkDeleteRowMismatchException"/> class.
+    /// </summary>
+    /// <param name="expectedRows">The number of rows expected to be affected.</param>
+    /// <param name="affectedRows">The number of rows actually affected.</param>
+    public BulkDeleteRowMismatchException(int expectedRows, int affectedRows)
+        : this(String.Format(CultureInfo.CurrentCulture, "Delete affected {0} rows, but expected {1}.", affectedRows, expectedRows), expectedRows, affectedRows)
+    {
+    }
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BulkDeleteRowMismatchException"/> class with a specific error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="expectedRows">The number of rows expected to be affected.</param>
+    /// <param name="affectedRows">The number of rows actually affected.</param>
+    public BulkDeleteRowMismatchException(string message, int expectedRows, int affectedRows)
+        : base(new Status(BaseStatusCode, message), StateStoreErrors.GetBulkDeleteRowMismatchErrorMetadata(BaseStatusCode, expectedRows, affectedRows))
+    {
+    }
+}

--- a/src/Dapr.PluggableComponents/Components/StateStore/ETagErrors.cs
+++ b/src/Dapr.PluggableComponents/Components/StateStore/ETagErrors.cs
@@ -1,0 +1,67 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Google.Protobuf;
+using Google.Rpc;
+using Grpc.Core;
+
+namespace Dapr.PluggableComponents.Components.StateStore;
+
+internal static class StateStoreErrors
+{
+    public static Metadata GetETagErrorMetadata(StatusCode statusCode, string message)
+    {
+        return GetMetadata(statusCode, GetETagFieldViolation(message));
+    }
+
+    public static Metadata GetBulkDeleteRowMismatchErrorMetadata(StatusCode statusCode, int expectedRows, int affectedRows)
+    {
+        var errorInfo = new Google.Rpc.ErrorInfo();
+
+        errorInfo.Metadata.Add("expected", expectedRows.ToString());
+        errorInfo.Metadata.Add("affected", affectedRows.ToString());
+
+        return GetMetadata(statusCode, errorInfo);
+    }
+
+    private static BadRequest GetETagFieldViolation(string message)
+    {
+        var badRequest = new BadRequest();
+
+        badRequest.FieldViolations.Add(
+            new Google.Rpc.BadRequest.Types.FieldViolation
+            {
+                Field = "etag",
+                Description = message
+            });
+
+        return badRequest;
+    }
+
+    private static Metadata GetMetadata(StatusCode baseStatusCode, IMessage message)
+    {
+        var status = new Google.Rpc.Status
+        {
+            Code = (int)baseStatusCode
+        };
+
+        status.Details.Add(Google.Protobuf.WellKnownTypes.Any.Pack(message));
+
+        var metadata = new Metadata();
+
+        metadata.Add("grpc-status-details-bin", status.ToByteArray());
+
+        return metadata;
+    }
+
+}

--- a/src/Dapr.PluggableComponents/Components/StateStore/ETagInvalidException.cs
+++ b/src/Dapr.PluggableComponents/Components/StateStore/ETagInvalidException.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Grpc.Core;
+
+namespace Dapr.PluggableComponents.Components.StateStore;
+
+/// <summary>
+/// An exception that represents an invalid ETag.
+/// </summary>
+/// <remarks>
+/// This exception should be thrown for ETag mismatches in the set, bulk set, delete, and bulk delete operations.
+/// </remarks>
+public sealed class ETagInvalidException : RpcException
+{
+    private static StatusCode BaseStatusCode = StatusCode.InvalidArgument;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ETagInvalidException"/> class.
+    /// </summary>
+    public ETagInvalidException()
+        : this("Invalid ETag value.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ETagInvalidException"/> class with a specific error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public ETagInvalidException(string message)
+        : base(new Status(BaseStatusCode, message), StateStoreErrors.GetETagErrorMetadata(BaseStatusCode, message))
+    {
+    }
+}

--- a/src/Dapr.PluggableComponents/Components/StateStore/ETagMismatchException.cs
+++ b/src/Dapr.PluggableComponents/Components/StateStore/ETagMismatchException.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Grpc.Core;
+
+namespace Dapr.PluggableComponents.Components.StateStore;
+
+/// <summary>
+/// An exception that represents a possible ETag mismatch.
+/// </summary>
+/// <remarks>
+/// This exception should be thrown for ETag mismatches in the set, bulk set, delete, and bulk delete operations.
+/// </remarks>
+public sealed class ETagMismatchException : RpcException
+{
+    private static StatusCode BaseStatusCode = StatusCode.FailedPrecondition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ETagMismatchException"/> class.
+    /// </summary>
+    public ETagMismatchException()
+        : this("Possible ETag mismatch.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ETagMismatchException"/> class with a specific error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public ETagMismatchException(string message)
+        : base(new Status(BaseStatusCode, message), StateStoreErrors.GetETagErrorMetadata(BaseStatusCode, message))
+    {
+    }
+}


### PR DESCRIPTION
Enables .NET Pluggable Component state stores to return ETag-specific errors to the Dapr runtime, as described in [dapr/dapr#5520](https://github.com/dapr/dapr/issues/5520). These are exposed as a set of custom exceptions to be thrown in those scenarios.