### PR TITLE
Remove BulkGetResponse.Got property.

### DIFF
--- a/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
+++ b/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProtosVersion>v1</ProtosVersion>
-    <ProtosTag>master</ProtosTag>
+    <ProtosTag>v1.11.0</ProtosTag>
     <ProtosBaseUrl>https://raw.githubusercontent.com/dapr/dapr/$(ProtosTag)/dapr/proto/components/$(ProtosVersion)</ProtosBaseUrl>
     <ProtosRootDir>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\Protos</ProtosRootDir>
     <ProtosComponentsDir>$(ProtosRootDir)\dapr\proto\components\$(ProtosVersion)</ProtosComponentsDir>

--- a/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
+++ b/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProtosVersion>v1</ProtosVersion>
-    <ProtosTag>v1.9.0</ProtosTag>
+    <ProtosTag>master</ProtosTag>
     <ProtosBaseUrl>https://raw.githubusercontent.com/dapr/dapr/$(ProtosTag)/dapr/proto/components/$(ProtosVersion)</ProtosBaseUrl>
     <ProtosRootDir>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\Protos</ProtosRootDir>
     <ProtosComponentsDir>$(ProtosRootDir)\dapr\proto\components\$(ProtosVersion)</ProtosComponentsDir>

--- a/src/Dapr.PluggableComponents.Tests/Adaptors/StateStoreAdaptorTests.cs
+++ b/src/Dapr.PluggableComponents.Tests/Adaptors/StateStoreAdaptorTests.cs
@@ -189,7 +189,6 @@ public sealed class StateStoreAdaptorTests
             bulkGetRequest,
             fixture.Context);
 
-        Assert.True(response.Got);
         Assert.Contains(response.Items, item => item.Key == key1 && item.Data.ToStringUtf8() == value1);
         Assert.Contains(response.Items, item => item.Key == key2 && item.Data.ToStringUtf8() == value2);
 
@@ -227,7 +226,6 @@ public sealed class StateStoreAdaptorTests
             bulkGetRequest,
             fixture.Context);
 
-        Assert.True(response.Got);
         Assert.Contains(response.Items, item => item.Key == key1 && item.Data.ToStringUtf8() == value1);
         Assert.Contains(response.Items, item => item.Key == key2 && item.Data.ToStringUtf8() == value2);
 

--- a/src/Dapr.PluggableComponents/Adaptors/StateStoreAdaptor.cs
+++ b/src/Dapr.PluggableComponents/Adaptors/StateStoreAdaptor.cs
@@ -85,10 +85,7 @@ public class StateStoreAdaptor : StateStoreBase
                 request.Items.Select(StateStoreGetRequest.FromGetRequest).ToArray(),
                 context.CancellationToken);
 
-            var response = new BulkGetResponse
-            {
-                Got = items.Any(item => String.IsNullOrEmpty(item.Error))
-            };
+            var response = new BulkGetResponse();
 
             response.Items.Add(items.Select(StateStoreBulkStateItem.ToBulkStateItem));
 
@@ -107,10 +104,7 @@ public class StateStoreAdaptor : StateStoreBase
                 responses.Add(StateStoreGetResponse.ToBulkStateItem(item.Key, response));
             }
 
-            var grpcResponse = new BulkGetResponse
-            {
-                Got = responses.Any(item => String.IsNullOrEmpty(item.Error))
-            };
+            var grpcResponse = new BulkGetResponse();
 
             grpcResponse.Items.Add(responses);
 


### PR DESCRIPTION
> Do not merge until dapr/dapr has an official 1.11 branch and this PR is updated to pull protos from that branch.

# Description

Updates the `BulkGetResponse` type, removing the the `Got` property which has been removed from the protos in Dapr 1.11.  The runtime in this release consolidates the handling of bulk operations such that the property is no longer needed. As a change to the protos is breaking, the pluggable component SDKs must be updated to match.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #33 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
