### PR TITLE
Move from Moq to NSubstitute

### DIFF
--- a/src/Dapr.PluggableComponents.Tests/Adaptors/AdaptorFixture.cs
+++ b/src/Dapr.PluggableComponents.Tests/Adaptors/AdaptorFixture.cs
@@ -129,7 +129,7 @@ internal abstract class AdaptorFixture
         Func<AdaptorFixture<TAdaptor, TInterface>, Task> pingCall)
         where TInterface : class, IPluggableComponent
     {
-        using var fixture = adaptorFactory(null);
+        using var fixture = adaptorFactory(Substitute.For<TInterface, IPluggableComponentLiveness>());
 
         var mockLiveness = (IPluggableComponentLiveness)fixture.MockComponent;
 

--- a/src/Dapr.PluggableComponents.Tests/Adaptors/AdaptorFixture.cs
+++ b/src/Dapr.PluggableComponents.Tests/Adaptors/AdaptorFixture.cs
@@ -17,7 +17,7 @@ using Dapr.PluggableComponents.Components.PubSub;
 using Dapr.PluggableComponents.Components.StateStore;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Dapr.PluggableComponents.Adaptors;
 
@@ -26,11 +26,11 @@ internal sealed class AdaptorFixture<TAdaptor, TInterface> : AdaptorFixture, IDi
 {
     private readonly Lazy<TAdaptor> adaptor;
 
-    public AdaptorFixture(Func<ILogger<TAdaptor>, IDaprPluggableComponentProvider<TInterface>, TAdaptor> adaptorFactory, Mock<TInterface>? mockComponent = null)
+    public AdaptorFixture(Func<ILogger<TAdaptor>, IDaprPluggableComponentProvider<TInterface>, TAdaptor> adaptorFactory, TInterface? mockComponent = null)
     {
-        this.MockComponent = mockComponent ?? new Mock<TInterface>();
+        this.MockComponent = mockComponent ?? Substitute.For<TInterface>();
 
-        this.adaptor = new Lazy<TAdaptor>(() => Create<TAdaptor, TInterface>(this.MockComponent.Object, adaptorFactory));
+        this.adaptor = new Lazy<TAdaptor>(() => Create<TAdaptor, TInterface>(this.MockComponent, adaptorFactory));
     }
 
     /// <remarks>
@@ -41,7 +41,7 @@ internal sealed class AdaptorFixture<TAdaptor, TInterface> : AdaptorFixture, IDi
 
     public TestServerCallContext Context { get; } = new TestServerCallContext();
 
-    public Mock<TInterface> MockComponent { get; }
+    public TInterface MockComponent { get; }
 
     #region IDisposable Members
 
@@ -55,22 +55,22 @@ internal sealed class AdaptorFixture<TAdaptor, TInterface> : AdaptorFixture, IDi
 
 internal abstract class AdaptorFixture
 {
-    public static AdaptorFixture<InputBindingAdaptor, IInputBinding> CreateInputBinding(Mock<IInputBinding>? mockComponent = null)
+    public static AdaptorFixture<InputBindingAdaptor, IInputBinding> CreateInputBinding(IInputBinding? mockComponent = null)
     {
         return new AdaptorFixture<InputBindingAdaptor, IInputBinding>((logger, componentProvider) => new InputBindingAdaptor(logger, componentProvider), mockComponent);
     }
 
-    public static AdaptorFixture<OutputBindingAdaptor, IOutputBinding> CreateOutputBinding(Mock<IOutputBinding>? mockComponent = null)
+    public static AdaptorFixture<OutputBindingAdaptor, IOutputBinding> CreateOutputBinding(IOutputBinding? mockComponent = null)
     {
         return new AdaptorFixture<OutputBindingAdaptor, IOutputBinding>((logger, componentProvider) => new OutputBindingAdaptor(logger, componentProvider), mockComponent);
     }
 
-    public static AdaptorFixture<PubSubAdaptor, IPubSub> CreatePubSub(Mock<IPubSub>? mockComponent = null)
+    public static AdaptorFixture<PubSubAdaptor, IPubSub> CreatePubSub(IPubSub? mockComponent = null)
     {
         return new AdaptorFixture<PubSubAdaptor, IPubSub>((logger, componentProvider) => new PubSubAdaptor(logger, componentProvider), mockComponent);
     }
 
-    public static AdaptorFixture<StateStoreAdaptor, IStateStore> CreateStateStore(Mock<IStateStore>? mockComponent = null)
+    public static AdaptorFixture<StateStoreAdaptor, IStateStore> CreateStateStore(IStateStore? mockComponent = null)
     {
         return new AdaptorFixture<StateStoreAdaptor, IStateStore>((logger, componentProvider) => new StateStoreAdaptor(logger, componentProvider), mockComponent);
     }
@@ -83,7 +83,8 @@ internal abstract class AdaptorFixture
         using var fixture = adaptorFactory();
 
         fixture.MockComponent
-            .Setup(component => component.InitAsync(It.IsAny<Components.MetadataRequest>(), It.IsAny<CancellationToken>()));
+            .InitAsync(Arg.Any<Components.MetadataRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
 
         var properties = new Dictionary<string, string>()
         {
@@ -97,16 +98,15 @@ internal abstract class AdaptorFixture
 
         await initCall(fixture, metadataRequest);
 
-        fixture.MockComponent
-            .Verify(
-                component => component.InitAsync(
-                    It.Is<Components.MetadataRequest>(request => ConversionAssert.MetadataEqual(properties, request.Properties)),
-                    It.Is<CancellationToken>(token => token == fixture.Context.CancellationToken)),
-                Times.Once());
+        await fixture.MockComponent
+            .Received(1)
+            .InitAsync(
+                    Arg.Is<Components.MetadataRequest>(request => ConversionAssert.MetadataEqual(properties, request.Properties)),
+                    Arg.Is<CancellationToken>(token => token == fixture.Context.CancellationToken));
     }
 
     public static async Task TestPingAsync<TAdaptor, TInterface>(
-        Func<Mock<TInterface>?, AdaptorFixture<TAdaptor, TInterface>> adaptorFactory,
+        Func<TInterface?, AdaptorFixture<TAdaptor, TInterface>> adaptorFactory,
         Func<AdaptorFixture<TAdaptor, TInterface>, Task> pingCall)
         where TInterface : class, IPluggableComponent
     {
@@ -115,46 +115,45 @@ internal abstract class AdaptorFixture
     }
 
     private static async Task PingWithNoLiveness<TAdaptor, TInterface>(
-        Func<Mock<TInterface>?, AdaptorFixture<TAdaptor, TInterface>> adaptorFactory,
+        Func<TInterface?, AdaptorFixture<TAdaptor, TInterface>> adaptorFactory,
         Func<AdaptorFixture<TAdaptor, TInterface>, Task> pingCall)
         where TInterface : class, IPluggableComponent
     {
-        using var fixture = adaptorFactory(new Mock<TInterface>(MockBehavior.Strict));
+        using var fixture = adaptorFactory(Substitute.For<TInterface>());
 
         await pingCall(fixture);
     }
 
     private static async Task PingWithLiveness<TAdaptor, TInterface>(
-        Func<Mock<TInterface>?, AdaptorFixture<TAdaptor, TInterface>> adaptorFactory,
+        Func<TInterface?, AdaptorFixture<TAdaptor, TInterface>> adaptorFactory,
         Func<AdaptorFixture<TAdaptor, TInterface>, Task> pingCall)
         where TInterface : class, IPluggableComponent
     {
         using var fixture = adaptorFactory(null);
 
-        var mockLiveness = fixture.MockComponent.As<IPluggableComponentLiveness>();
+        var mockLiveness = (IPluggableComponentLiveness)fixture.MockComponent;
 
         mockLiveness
-            .Setup(component => component.PingAsync(It.IsAny<CancellationToken>()));
+            .PingAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
 
         await pingCall(fixture);
 
-        mockLiveness
-            .Verify(
-                component => component.PingAsync(
-                    It.Is<CancellationToken>(token => token == fixture.Context.CancellationToken)),
-                Times.Once());
+        await mockLiveness
+            .Received(1)
+            .PingAsync(Arg.Is<CancellationToken>(token => token == fixture.Context.CancellationToken));
     }
 
     protected static TAdaptor Create<TAdaptor, TInterface>(TInterface component, Func<ILogger<TAdaptor>, IDaprPluggableComponentProvider<TInterface>, TAdaptor> adaptorFactory)
     {
-        var logger = new Mock<ILogger<TAdaptor>>();
+        var logger = Substitute.For<ILogger<TAdaptor>>();
 
-        var mockComponentProvider = new Mock<IDaprPluggableComponentProvider<TInterface>>();
+        var mockComponentProvider = Substitute.For<IDaprPluggableComponentProvider<TInterface>>();
 
         mockComponentProvider
-            .Setup(componentProvider => componentProvider.GetComponent(It.IsAny<ServerCallContext>()))
+            .GetComponent(Arg.Any<ServerCallContext>())
             .Returns(component);
 
-        return adaptorFactory(logger.Object, mockComponentProvider.Object);
+        return adaptorFactory(logger, mockComponentProvider);
     }
 }

--- a/src/Dapr.PluggableComponents.Tests/Adaptors/PubSubAdaptorTests.cs
+++ b/src/Dapr.PluggableComponents.Tests/Adaptors/PubSubAdaptorTests.cs
@@ -44,7 +44,7 @@ public sealed class PubSubAdaptorTests
     [Fact]
     public async Task FeaturesWithNoFeatures()
     {
-        using var fixture = AdaptorFixture.CreatePubSub(Substitute.For<IPubSub>());
+        using var fixture = AdaptorFixture.CreatePubSub();
 
         var response = await fixture.Adaptor.Features(
             new FeaturesRequest(),

--- a/src/Dapr.PluggableComponents.Tests/Adaptors/StateStoreAdaptorTests.cs
+++ b/src/Dapr.PluggableComponents.Tests/Adaptors/StateStoreAdaptorTests.cs
@@ -40,7 +40,7 @@ public sealed class StateStoreAdaptorTests
     [Fact]
     public async Task SimulatedBulkDelete()
     {
-        using var fixture = AdaptorFixture.CreateStateStore(Substitute.For<IStateStore>());
+        using var fixture = AdaptorFixture.CreateStateStore();
 
         string key1 = "key1";
         string key2 = "key2";
@@ -99,8 +99,7 @@ public sealed class StateStoreAdaptorTests
     [Fact]
     public async Task SimulatedBulkSet()
     {
-        // TODO: Need to specify Strict?
-        using var fixture = AdaptorFixture.CreateStateStore(Substitute.For<IStateStore>());
+        using var fixture = AdaptorFixture.CreateStateStore();
 
         string key1 = "key1";
         string key2 = "key2";
@@ -159,7 +158,7 @@ public sealed class StateStoreAdaptorTests
     [Fact]
     public async Task SimulatedBulkGet()
     {
-        using var fixture = AdaptorFixture.CreateStateStore(Substitute.For<IStateStore>());
+        using var fixture = AdaptorFixture.CreateStateStore();
 
         string key1 = "key1";
         string key2 = "key2";

--- a/src/Dapr.PluggableComponents.Tests/Adaptors/StateStoreAdaptorTests.cs
+++ b/src/Dapr.PluggableComponents.Tests/Adaptors/StateStoreAdaptorTests.cs
@@ -89,6 +89,8 @@ public sealed class StateStoreAdaptorTests
             bulkDeleteRequest,
             fixture.Context);
 
+        await fixture.MockComponent.DidNotReceive().DeleteAsync(Arg.Any<StateStoreDeleteRequest>(), Arg.Any<CancellationToken>());
+
         await mockBulkStateStore
             .Received(1)
             .BulkDeleteAsync(
@@ -147,6 +149,8 @@ public sealed class StateStoreAdaptorTests
         await fixture.Adaptor.BulkSet(
             bulkSetRequest,
             fixture.Context);
+
+        await fixture.MockComponent.DidNotReceive().SetAsync(Arg.Any<StateStoreSetRequest>(), Arg.Any<CancellationToken>());
 
         await mockBulkStateStore
             .Received(1)
@@ -227,6 +231,8 @@ public sealed class StateStoreAdaptorTests
 
         Assert.Contains(response.Items, item => item.Key == key1 && item.Data.ToStringUtf8() == value1);
         Assert.Contains(response.Items, item => item.Key == key2 && item.Data.ToStringUtf8() == value2);
+
+        await fixture.MockComponent.DidNotReceive().GetAsync(Arg.Any<StateStoreGetRequest>(), Arg.Any<CancellationToken>());
 
         await mockBulkStateStore
             .Received(1)

--- a/src/Dapr.PluggableComponents.Tests/Dapr.PluggableComponents.Tests.csproj
+++ b/src/Dapr.PluggableComponents.Tests/Dapr.PluggableComponents.Tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description

Replaces the Moq .NET unit test mock library with NSubstitute, due to its recent [privacy concerns](https://github.com/moq/moq/issues/1372).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #40 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
