### PR TITLE
Update needed to support Windows.

### DIFF
--- a/src/Dapr.PluggableComponents.AspNetCore/WebApplicationBuilderExtensions.cs
+++ b/src/Dapr.PluggableComponents.AspNetCore/WebApplicationBuilderExtensions.cs
@@ -56,10 +56,9 @@ public static class WebApplicationBuilderExtensions
             ?? Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.DaprComponentsSocketsExtension)
             ?? Constants.Defaults.DaprComponentsSocketsExtension;
 
-        // TODO: Add support for native (i.e. non-WSL) Windows.
         string socketFolder = options.SocketFolder
             ?? Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.DaprComponentsSocketsFolder)
-            ?? Constants.Defaults.DaprComponentsSocketsFolder;
+            ?? Path.Combine(Path.GetTempPath(), Constants.Defaults.DaprComponentsSocketsFolder);
 
         string socketName = options.SocketName;
 

--- a/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
+++ b/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.6.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.21.9" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.50.0">
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.13.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.60.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Dapr.PluggableComponents/Constants.cs
+++ b/src/Dapr.PluggableComponents/Constants.cs
@@ -29,12 +29,9 @@ public static class Constants
         public const string DaprComponentsSocketsExtension = ".sock";
 
         /// <summary>
-        /// The default directory in which Dapr Pluggable Components create their socket files.
+        /// The default temp sub-directory in which Dapr Pluggable Components create their socket files.
         /// </summary>
-        /// <remarks>
-        /// This location is applicable only to Mac OS and Linux platforms.
-        /// </remarks>
-        public const string DaprComponentsSocketsFolder = "/tmp/dapr-components-sockets";
+        public const string DaprComponentsSocketsFolder = "dapr-components-sockets";
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

Some tweaks to support native Windows support:

 - Use the .NET-determined temp path for each platform
 - Do not attempt to adjust permissions of sockets files on Windows (as it's not necessary and not supported)
 - Updates gRPC dependencies to work around issue building on Windows ARM64

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #44 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
