### PR TITLE
Remove .NET 7 build target and update dependencies.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0','7.0','8.0']
+        dotnet-version: ['6.0','8.0']
         include:
         - dotnet-version: '6.0'
           install-3: false
@@ -62,12 +62,6 @@ jobs:
           framework: 'net6.0'
           prefix: 'net6'
           install-version: '6.0.x'
-        - dotnet-version: '7.0'
-          install-3: false
-          display-name: '.NET 7.0'
-          framework: 'net7.0'
-          prefix: 'net7'
-          install-version: '7.0.x'
         - dotnet-version: '8.0'
           install-3: false
           display-name: '.NET 8.0'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,24 +3,24 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
-    <PackageVersion Include="Discord.Net" Version="3.9.0" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
-    <PackageVersion Include="Google.Api.CommonProtos" Version="2.13.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.20.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageVersion Include="Discord.Net" Version="3.16.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="Google.Api.CommonProtos" Version="2.16.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.66.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.66.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.60.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.60.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="MinVer" Version="4.2.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.67.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.1" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,26 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.12.0" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageVersion Include="Discord.Net" Version="3.9.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
+    <PackageVersion Include="Google.Api.CommonProtos" Version="2.13.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.66.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.66.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.60.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.60.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="MinVer" Version="4.2.0" />
+    <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This SDK provides a better interface to create Pluggable Components without worr
 
 ## Prerequisites
 
-- [.NET 6 SDK](https://dotnet.microsoft.com/) or later
+- [.NET 6 or .NET 8 SDK](https://dotnet.microsoft.com/)
 - [Dapr](https://dapr.io/)
 
   ### SDK and Dapr Compatibility
@@ -15,6 +15,7 @@ This SDK provides a better interface to create Pluggable Components without worr
   |-------------|--------------------------|-------|
   | v0.1.x | v1.10 | Using SDK with Dapr v1.9 will not have ETag error handling. |
   | v0.2.x | v1.11 | Dapr state store API changes require use of the 0.2.0 SDK. |
+  | v0.3.x | v1.14 | |
 
 ## Implementing a Pluggable Component
 

--- a/samples/AzureStorageQueuesPubSubSample/AzureStorageQueuesPubSubSample.csproj
+++ b/samples/AzureStorageQueuesPubSubSample/AzureStorageQueuesPubSubSample.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+    <PackageReference Include="Azure.Storage.Queues" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>

--- a/samples/DiscordBindingSample/DiscordBindingSample.csproj
+++ b/samples/DiscordBindingSample/DiscordBindingSample.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.1" />
-    <PackageReference Include="Discord.Net" Version="3.9.0" />
+    <PackageReference Include="Azure.Storage.Queues" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Discord.Net" />
   </ItemGroup>
 </Project>

--- a/src/Dapr.PluggableComponents.AspNetCore/Dapr.PluggableComponents.AspNetCore.csproj
+++ b/src/Dapr.PluggableComponents.AspNetCore/Dapr.PluggableComponents.AspNetCore.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.50.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.50.0" />
-    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
+    <PackageReference Include="Grpc.AspNetCore.Server" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" />
+    <PackageReference Include="Mono.Unix" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
+++ b/src/Dapr.PluggableComponents.Protos/Dapr.PluggableComponents.Protos.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.13.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.60.0">
+    <PackageReference Include="Google.Api.CommonProtos" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Grpc.Tools">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Dapr.PluggableComponents.Tests/Dapr.PluggableComponents.Tests.csproj
+++ b/src/Dapr.PluggableComponents.Tests/Dapr.PluggableComponents.Tests.csproj
@@ -10,18 +10,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -29,7 +29,7 @@
 
   <!-- Used to annotate PR with test failures: https://github.com/Tyrrrz/GitHubActionsTestLogger -->
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.2" />
+    <PackageReference Include="GitHubActionsTestLogger" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.PluggableComponents.Tests/DaprPluggableComponentsApplicationTests.cs
+++ b/src/Dapr.PluggableComponents.Tests/DaprPluggableComponentsApplicationTests.cs
@@ -48,15 +48,20 @@ public sealed class DaprPluggableComponentsApplicationTests
     }
 
     [Fact(Timeout = TimeoutInMs)]
-    public void Run()
+    public async Task Run()
     {
         var application = DaprPluggableComponentsApplication.Create();
 
-        Task.Delay(TimeSpan.FromSeconds(1))
-            .ContinueWith(task => application.StopAsync())
-            .Unwrap()
-            .ContinueWith(task => Assert.Fail("Unable to stop application."), TaskContinuationOptions.OnlyOnFaulted);
+        var runTask = Task.Run(
+            () =>
+            {
+                application.Run();
+            });
 
-        application.Run();
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        await application.StopAsync();
+
+        await runTask;
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -57,7 +57,7 @@
   <!-- Configure properties for MinVer -->
   <PropertyGroup>
     <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerDefaultPreReleasePhase>rc</MinVerDefaultPreReleasePhase>
+    <MinVerDefaultPreReleaseIdentifiers>rc.0</MinVerDefaultPreReleaseIdentifiers>
     <!-- <MinVerVerbosity>detailed</MinVerVerbosity>-->
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -48,7 +48,7 @@
 
   <!-- Use MinVer for assembly, nuget versioning based on git tags -->
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="4.2.0">
+    <PackageReference Include="MinVer">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 
   <!-- Enable Deterministic Builds for github actions -->


### PR DESCRIPTION
# Description

 - Removes the .NET 7 build target
 - Moves to central package management
 - Updates dependencies
 - Updates README

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #51

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
